### PR TITLE
Add GitHub Actions build and auto-release workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,72 @@
+name: build
+
+on:
+  push:
+    branches:
+      - master
+      - main
+    tags:
+      - "*"
+  pull_request:
+
+jobs:
+  build:
+    name: Build fonts
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Set up Python
+        uses: actions/setup-python@v2
+        with:
+          python-version: 3.x
+
+      - name: Install pip packages
+        run: |
+          pip install fonttools fontmake afdko psautohint
+
+      # - name: Process cache
+      #   id: cache
+      #   uses: actions/cache@v2
+      #   with:
+      #     path: ${{ env.TEBAKO_DIR }}/${{ env.DEPS }}
+      #     key: ${{ github.workflow }}-${{ matrix.os }}-${{ matrix.env.CC }}-${{ hashFiles('key.txt') }}-v01
+
+      - name: Build fonts
+        run: |
+          python3 tools/03_build_lato_fontmake.py
+
+      - name: Package fonts
+        run: |
+          mkdir -p dist
+          zip -r dist/lato-static-otf.zip ../build/Lato3Ita2M/static-otf/* ../build/Lato3Upr2M/static-otf/*
+          zip -r dist/lato-static-ttf.zip ../build/Lato3Ita2M/static-ttf/* ../build/Lato3Upr2M/static-ttf/*
+
+      - uses: actions/upload-artifact@v2
+        with:
+          name: lato-static-fonts
+          path: dist/
+
+  release:
+    if: startsWith(github.ref, 'refs/tags/')
+    runs-on: ubuntu-latest
+    needs: build
+    steps:
+      - uses: actions/download-artifact@v2
+        with:
+          name: lato-static-fonts
+          path: dist
+
+      - uses: softprops/action-gh-release@v1
+        if: startsWith(github.ref, 'refs/tags/')
+        with:
+          files: dist/lato-static-otf.zip
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - uses: softprops/action-gh-release@v1
+        if: startsWith(github.ref, 'refs/tags/')
+        with:
+          files: dist/lato-static-ttf.zip
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
This fixes #23.

Some users use Lato in their continuous integration builds (e.g. publishing PDFs, such as in [Metanorma](https://github.com/metanorma/metanorma-ogc)).

As a user of Lato we have run into a few operational issues that could be solved:

1. The latest Lato fonts (3.100dev) are not available from the official website.
2. The official website font link becomes unavailable occasionally. (e.g. [Lato font always unavailable from official URL fontist/formulas#112](https://github.com/fontist/formulas/issues/112))

This PR provides a GitHub Actions workflow that:
* automatically publishes releases at the repository given a Git tag (e.g. `v3.100.dev2`)
* automatically builds fonts on changes in the `master` branch and PRs (according to instructions in the README)
